### PR TITLE
fixing user and non-user intialized MPI wrapper

### DIFF
--- a/examples/PowerGrid/test_case9.sh
+++ b/examples/PowerGrid/test_case9.sh
@@ -1,20 +1,20 @@
 # runing test for case9 
 echo "#####################################################"
-echo "Teting (StructJuMP + Ipopt) Model: SC-ACOPF  Data: case9 with 2 contingencies"
+echo "Testing (StructJuMP + Ipopt) Model: SC-ACOPF  Data: case9 with 2 contingencies"
 julia scopf_structjump_main.jl Ipopt false  data/case9 2 8
 #julia scopf_structjump_main.jl Ipopt true data/case9 2 8
 echo "#####################################################"
-echo "Teting (StructJuMP + PipsNlp) Model: SC-ACOPF Data: case9 with 2 contingencies"
+echo "Testing (StructJuMP + PipsNlp) Model: SC-ACOPF Data: case9 with 2 contingencies"
 julia scopf_structjump_main.jl PipsNlp false  data/case9 2 8
 #julia scopf_structjump_main.jl PipsNlp true data/case9 2 8
 echo "#####################################################"
-echo "Teting (StructJuMP + PipsNlpSerial) Model: SC-ACOPF  Data: case9 with 2 contingencies"
+echo "Testing (StructJuMP + PipsNlpSerial) Model: SC-ACOPF  Data: case9 with 2 contingencies"
 julia scopf_structjump_main.jl PipsNlpSerial false  data/case9 2 8
 #julia scopf_structjump_main.jl PipsNlpSerial true data/case9 2 8
 echo "#####################################################"
-echo "Teting (JuMP + Ipopt) Model: SC-ACOPF, Data: case9 with 2 contingencies"
+echo "Testing (JuMP + Ipopt) Model: SC-ACOPF, Data: case9 with 2 contingencies"
 julia scopf_main.jl data/case9 2 8
 echo "#####################################################"
-echo "Teting (JuMP + Ipopt) Model: ACOPF,  Data: case9"
+echo "Testing (JuMP + Ipopt) Model: ACOPF,  Data: case9"
 julia acopf_main.jl data/case9 
 echo "#####################################################"


### PR DESCRIPTION
This fixe allows multiple model instances to be created and solved in a one julia console process. 
Every model instance are now using the same mpiWrapper object that will be destructed when it is out of scope (when julia is exited). 