### PR TITLE
Update power grid example to be compatible with Julia 0.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Problems modeled in StructJuMP models can be solved in parallel using the [PIPS-
 ### Mixed-Integer Solvers
 [DSP](https://github.com/Argonne-National-Laboratory/DSP.git) can read models from StructJuMP via [DSPsolver.jl](https://github.com/Argonne-National-Laboratory/DSPsolver.jl.git). In particular, ``DSP`` can solver problems with integer variables in parallel.
 
-### Stochastic Dual Dynamic Programming
-[Stochastic Dual Dynamic Programming](https://github.com/blegat/StochasticDualDynamicProgramming.jl) can read multi-stage models from StructJuMP.
+### Stochastic Dual Dynamic Programming (SDDP)
+[StructDualDynProg](https://github.com/blegat/StructDualDynProg.jl) can run the SDDP algorithm on multi-stage models from StructJuMP.
 
 ## Acknowledgements
 StructJuMP has been developed under the financial support of Department of Energy (DOE), Office of Advanced Scientific Computing Research, Office of Electricity Delivery and Energy Reliability, and Grid Modernization Laboratory Consortium (GMLC) (PIs: Cosmin G. Petra, Lawrence Livermore National Laboratory and Mihai Anitescu, Argonne National Laboratory).

--- a/examples/PowerGrid/acopf.jl
+++ b/examples/PowerGrid/acopf.jl
@@ -8,10 +8,10 @@ function acopf_solve(opfmodel, opf_data)
   # Initial point - needed especially for pegase cases
   #
   Pg0,Qg0,Vm0,Va0 = acopf_initialPt_IPOPT(opf_data)
-  setvalue(getvariable(opfmodel, :Pg), Pg0)  
-  setvalue(getvariable(opfmodel, :Qg), Qg0)
-  setvalue(getvariable(opfmodel, :Vm), Vm0)
-  setvalue(getvariable(opfmodel, :Va), Va0)
+  setvalue(getindex(opfmodel, :Pg), Pg0)  
+  setvalue(getindex(opfmodel, :Qg), Qg0)
+  setvalue(getindex(opfmodel, :Vm), Vm0)
+  setvalue(getindex(opfmodel, :Va), Va0)
 
   status = solve(opfmodel)
 
@@ -154,8 +154,8 @@ function acopf_outputAll(opfmodel, opf_data)
 
   # OUTPUTING
   println("Objective value: ", getobjectivevalue(opfmodel), "USD/hr")
-  VM=getvalue(getvariable(opfmodel,:Vm)); VA=getvalue(getvariable(opfmodel,:Va))
-  PG=getvalue(getvariable(opfmodel,:Pg)); QG=getvalue(getvariable(opfmodel,:Qg))
+  VM=getvalue(getindex(opfmodel,:Vm)); VA=getvalue(getindex(opfmodel,:Va))
+  PG=getvalue(getindex(opfmodel,:Pg)); QG=getvalue(getindex(opfmodel,:Qg))
 
   println("============================= BUSES ==================================")
   println("  BUS    Vm     Va   |   Pg (MW)    Qg(MVAr) ")   # |    P (MW)     Q (MVAr)")  #|         (load)   ") 

--- a/examples/PowerGrid/opfdata.jl
+++ b/examples/PowerGrid/opfdata.jl
@@ -78,7 +78,7 @@ function opf_loaddata(case_name, lineOff=Line())
   # bus_arr = readdlm("data/" * case_name * ".bus")
   bus_arr = readdlm(case_name * ".bus")
   num_buses = size(bus_arr,1)
-  buses = Array(Bus, num_buses)
+  buses = Array{Bus}(num_buses)
   bus_ref=-1
   for i in 1:num_buses
     @assert bus_arr[i,1]>0  #don't support nonpositive bus ids
@@ -100,7 +100,7 @@ function opf_loaddata(case_name, lineOff=Line())
   # branch_arr = readdlm("data/" * case_name * ".branch")
   branch_arr = readdlm(case_name * ".branch")
   num_lines = size(branch_arr,1)
-  lines_on = find((branch_arr[:,11].>0) & ((branch_arr[:,1].!=lineOff.from) | (branch_arr[:,2].!=lineOff.to)) )
+  lines_on = find((branch_arr[:,11].>0) .& ((branch_arr[:,1].!=lineOff.from) .| (branch_arr[:,2].!=lineOff.to)) )
   num_on   = length(lines_on)
 
   if lineOff.from>0 && lineOff.to>0 
@@ -113,7 +113,7 @@ function opf_loaddata(case_name, lineOff=Line())
 
 
 
-  lines = Array(Line, num_on)
+  lines = Array{Line}(num_on)
 
   lit=0
   for i in lines_on
@@ -145,11 +145,11 @@ function opf_loaddata(case_name, lineOff=Line())
     println("loaddata: ", num_gens-num_on, " generators are off and will be discarded (out of ", num_gens, ")")
   end
 
-  generators = Array(Gener, num_on)
+  generators = Array{Gener}(num_on)
   i=0
   for git in gens_on
     i += 1
-    generators[i] = Gener(0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, Array(Int,0)) #gen_arr[i,1:end]...)
+    generators[i] = Gener(0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, Array{Int}(0)) #gen_arr[i,1:end]...)
 
     generators[i].bus      = gen_arr[git,1]
     generators[i].Pg       = gen_arr[git,2] / baseMVA
@@ -201,14 +201,14 @@ end
 
 function  computeAdmitances(lines, buses, baseMVA)
   nlines = length(lines)
-  YffR=Array(Float64,nlines)
-  YffI=Array(Float64,nlines)
-  YttR=Array(Float64,nlines) 
-  YttI=Array(Float64,nlines)
-  YftR=Array(Float64,nlines)
-  YftI=Array(Float64,nlines)
-  YtfR=Array(Float64,nlines)
-  YtfI=Array(Float64,nlines)
+  YffR=Array{Float64}(nlines)
+  YffI=Array{Float64}(nlines)
+  YttR=Array{Float64}(nlines) 
+  YttI=Array{Float64}(nlines)
+  YftR=Array{Float64}(nlines)
+  YftI=Array{Float64}(nlines)
+  YtfR=Array{Float64}(nlines)
+  YtfI=Array{Float64}(nlines)
 
   for i in 1:nlines
     @assert lines[i].status == 1 
@@ -233,24 +233,24 @@ function  computeAdmitances(lines, buses, baseMVA)
   end
 
   nbuses = length(buses)
-  YshR = Array(Float64,nbuses)
-  YshI = Array(Float64,nbuses)
+  YshR = Array{Float64}(nbuses)
+  YshI = Array{Float64}(nbuses)
   for i in 1:nbuses
     YshR[i] = buses[i].Gs / baseMVA
     YshI[i] = buses[i].Bs / baseMVA
     #@printf("[%4d]   Ysh  %15.12f + %15.12f i \n", i, YshR[i], YshI[i])
   end
 
-  @assert 0==length(find(isnan(YffR)))+length(find(isinf(YffR)))
-  @assert 0==length(find(isnan(YffI)))+length(find(isinf(YffI)))
-  @assert 0==length(find(isnan(YttR)))+length(find(isinf(YttR)))
-  @assert 0==length(find(isnan(YttI)))+length(find(isinf(YttI)))
-  @assert 0==length(find(isnan(YftR)))+length(find(isinf(YftR)))
-  @assert 0==length(find(isnan(YftI)))+length(find(isinf(YftI)))
-  @assert 0==length(find(isnan(YtfR)))+length(find(isinf(YtfR)))
-  @assert 0==length(find(isnan(YtfI)))+length(find(isinf(YtfI)))
-  @assert 0==length(find(isnan(YshR)))+length(find(isinf(YshR)))
-  @assert 0==length(find(isnan(YshI)))+length(find(isinf(YshI)))
+  @assert 0==length(find(isnan.(YffR)))+length(find(isinf.(YffR)))
+  @assert 0==length(find(isnan.(YffI)))+length(find(isinf.(YffI)))
+  @assert 0==length(find(isnan.(YttR)))+length(find(isinf.(YttR)))
+  @assert 0==length(find(isnan.(YttI)))+length(find(isinf.(YttI)))
+  @assert 0==length(find(isnan.(YftR)))+length(find(isinf.(YftR)))
+  @assert 0==length(find(isnan.(YftI)))+length(find(isinf.(YftI)))
+  @assert 0==length(find(isnan.(YtfR)))+length(find(isinf.(YtfR)))
+  @assert 0==length(find(isnan.(YtfI)))+length(find(isinf.(YtfI)))
+  @assert 0==length(find(isnan.(YshR)))+length(find(isinf.(YshR)))
+  @assert 0==length(find(isnan.(YshI)))+length(find(isinf.(YshI)))
 
   return YffR, YffI, YttR, YttI, YftR, YftI, YtfR, YtfI, YshR, YshI
 end

--- a/examples/PowerGrid/opfdata_structjump.jl
+++ b/examples/PowerGrid/opfdata_structjump.jl
@@ -91,7 +91,7 @@ function opf_loaddata(raw::RawData, lineOff=Line())
   #
   bus_arr = raw.bus_arr
   num_buses = size(bus_arr,1)
-  buses = Array(Bus, num_buses)
+  buses = Array{Bus}(num_buses)
   bus_ref=-1
   for i in 1:num_buses
     @assert bus_arr[i,1]>0  #don't support nonpositive bus ids
@@ -112,7 +112,7 @@ function opf_loaddata(raw::RawData, lineOff=Line())
   #
   branch_arr = raw.branch_arr
   num_lines = size(branch_arr,1)
-  lines_on = find((branch_arr[:,11].>0) & ((branch_arr[:,1].!=lineOff.from) | (branch_arr[:,2].!=lineOff.to)) )
+  lines_on = find((branch_arr[:,11].>0) .& ((branch_arr[:,1].!=lineOff.from) .| (branch_arr[:,2].!=lineOff.to)) )
   num_on   = length(lines_on)
 
   if lineOff.from>0 && lineOff.to>0 
@@ -125,7 +125,7 @@ function opf_loaddata(raw::RawData, lineOff=Line())
 
 
 
-  lines = Array(Line, num_on)
+  lines = Array{Line}(num_on)
 
   lit=0
   for i in lines_on
@@ -155,11 +155,11 @@ function opf_loaddata(raw::RawData, lineOff=Line())
     println("loaddata: ", num_gens-num_on, " generators are off and will be discarded (out of ", num_gens, ")")
   end
 
-  generators = Array(Gener, num_on)
+  generators = Array{Gener}(num_on)
   i=0
   for git in gens_on
     i += 1
-    generators[i] = Gener(0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, Array(Int,0)) #gen_arr[i,1:end]...)
+    generators[i] = Gener(0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, Array{Int}(0)) #gen_arr[i,1:end]...)
 
     generators[i].bus      = gen_arr[git,1]
     generators[i].Pg       = gen_arr[git,2] / baseMVA
@@ -211,14 +211,14 @@ end
 
 function  computeAdmitances(lines, buses, baseMVA)
   nlines = length(lines)
-  YffR=Array(Float64,nlines)
-  YffI=Array(Float64,nlines)
-  YttR=Array(Float64,nlines) 
-  YttI=Array(Float64,nlines)
-  YftR=Array(Float64,nlines)
-  YftI=Array(Float64,nlines)
-  YtfR=Array(Float64,nlines)
-  YtfI=Array(Float64,nlines)
+  YffR=Array{Float64}(nlines)
+  YffI=Array{Float64}(nlines)
+  YttR=Array{Float64}(nlines) 
+  YttI=Array{Float64}(nlines)
+  YftR=Array{Float64}(nlines)
+  YftI=Array{Float64}(nlines)
+  YtfR=Array{Float64}(nlines)
+  YtfI=Array{Float64}(nlines)
 
   for i in 1:nlines
     @assert lines[i].status == 1 
@@ -243,24 +243,24 @@ function  computeAdmitances(lines, buses, baseMVA)
   end
 
   nbuses = length(buses)
-  YshR = Array(Float64,nbuses)
-  YshI = Array(Float64,nbuses)
+  YshR = Array{Float64}(nbuses)
+  YshI = Array{Float64}(nbuses)
   for i in 1:nbuses
     YshR[i] = buses[i].Gs / baseMVA
     YshI[i] = buses[i].Bs / baseMVA
     #@printf("[%4d]   Ysh  %15.12f + %15.12f i \n", i, YshR[i], YshI[i])
   end
 
-  @assert 0==length(find(isnan(YffR)))+length(find(isinf(YffR)))
-  @assert 0==length(find(isnan(YffI)))+length(find(isinf(YffI)))
-  @assert 0==length(find(isnan(YttR)))+length(find(isinf(YttR)))
-  @assert 0==length(find(isnan(YttI)))+length(find(isinf(YttI)))
-  @assert 0==length(find(isnan(YftR)))+length(find(isinf(YftR)))
-  @assert 0==length(find(isnan(YftI)))+length(find(isinf(YftI)))
-  @assert 0==length(find(isnan(YtfR)))+length(find(isinf(YtfR)))
-  @assert 0==length(find(isnan(YtfI)))+length(find(isinf(YtfI)))
-  @assert 0==length(find(isnan(YshR)))+length(find(isinf(YshR)))
-  @assert 0==length(find(isnan(YshI)))+length(find(isinf(YshI)))
+  @assert 0==length(find(isnan.(YffR)))+length(find(isinf.(YffR)))
+  @assert 0==length(find(isnan.(YffI)))+length(find(isinf.(YffI)))
+  @assert 0==length(find(isnan.(YttR)))+length(find(isinf.(YttR)))
+  @assert 0==length(find(isnan.(YttI)))+length(find(isinf.(YttI)))
+  @assert 0==length(find(isnan.(YftR)))+length(find(isinf.(YftR)))
+  @assert 0==length(find(isnan.(YftI)))+length(find(isinf.(YftI)))
+  @assert 0==length(find(isnan.(YtfR)))+length(find(isinf.(YtfR)))
+  @assert 0==length(find(isnan.(YtfI)))+length(find(isinf.(YtfI)))
+  @assert 0==length(find(isnan.(YshR)))+length(find(isinf.(YshR)))
+  @assert 0==length(find(isnan.(YshI)))+length(find(isinf.(YshI)))
 
   return YffR, YffI, YttR, YttI, YftR, YftI, YtfR, YtfI, YshR, YshI
 end

--- a/examples/PowerGrid/scopf_main.jl
+++ b/examples/PowerGrid/scopf_main.jl
@@ -12,7 +12,7 @@ function main()
 
   opfdata = opf_loaddata(ARGS[1])
 
-  lines_off=Array(Line, length(ARGS)-1)
+  lines_off=Array{Line}(length(ARGS)-1)
   for l in 1:length(lines_off)
     lines_off[l] = opfdata.lines[parse(Int,ARGS[l+1])]
   end

--- a/examples/PowerGrid/scopf_structjump.jl
+++ b/examples/PowerGrid/scopf_structjump.jl
@@ -18,7 +18,7 @@ end
 
 function scopf_model(raw::RawData)
   opfdata = opf_loaddata(raw) #load root node
-  lines_off=Array(Line, length(ARGS)-1)
+  lines_off=Array{Line}(length(ARGS)-1)
   for l in 1:length(lines_off)
     lines_off[l] = opfdata.lines[parse(Int,ARGS[l+1])]
   end
@@ -227,10 +227,10 @@ function scopf_structjump_outputAll(opfmodel, scopf_data)
 
   # OUTPUTING
   println("Objective value: ", getObjectiveVal(opfmodel), "USD/hr")
-  VM=getvalue(getvariable(opfmodel,:Vm)); VA=getvalue(getvariable(opfmodel,:Va))
-  PG=getvalue(getvariable(opfmodel,:Pg)); QG=getvalue(getvariable(opfmodel,:Qg))
+  VM=getvalue(getindex(opfmodel,:Vm)); VA=getvalue(getindex(opfmodel,:Va))
+  PG=getvalue(getindex(opfmodel,:Pg)); QG=getvalue(getindex(opfmodel,:Qg))
 
-  EX=getvalue(getvariable(opfmodel,:extra));
+  EX=getvalue(getindex(opfmodel,:extra));
 
   # printing the first stage variables
   println("============================= BUSES ==================================")
@@ -313,19 +313,19 @@ function scopf_init_x(scopfmodel,scopfdata)
       opfdata = opf_loaddata(raw)
       Pg0,Qg0,Vm0,Va0 = scopf_compute_x0(opfdata)
       extra0 = 0.025*Pg0
-      setvalue(getvariable(scopfmodel, :Pg), Pg0)
-      setvalue(getvariable(scopfmodel, :extra), extra0)  
-      setvalue(getvariable(scopfmodel, :Qg), Qg0)
-      setvalue(getvariable(scopfmodel, :Vm), Vm0)
-      setvalue(getvariable(scopfmodel, :Va), Va0)
+      setvalue(getindex(scopfmodel, :Pg), Pg0)
+      setvalue(getindex(scopfmodel, :extra), extra0)  
+      setvalue(getindex(scopfmodel, :Qg), Qg0)
+      setvalue(getindex(scopfmodel, :Vm), Vm0)
+      setvalue(getindex(scopfmodel, :Va), Va0)
     else
       mm = getchildren(scopfmodel)[i]
       opfdata_c=opf_loaddata(raw,lines_off[i]) 
       Pg0,Qg0,Vm0,Va0 = scopf_compute_x0(opfdata_c)
       extra0 = 0.025*Pg0
-      setvalue(getvariable(mm, :extra), extra0)
-      setvalue(getvariable(mm, :Vm), Vm0)
-      setvalue(getvariable(mm, :Va), Va0)
+      setvalue(getindex(mm, :extra), extra0)
+      setvalue(getindex(mm, :Vm), Vm0)
+      setvalue(getindex(mm, :Va), Va0)
     end
   end
 end

--- a/src/BendersBridge.jl
+++ b/src/BendersBridge.jl
@@ -41,7 +41,7 @@ function conicconstraintdata(m::Model)
     # constr_to_row is not used but fill_bounds_constr! and fillconstr! for SDP needs them
     constr_to_row = Array{Vector{Int}}(numBounds + 2*length(m.sdpconstr))
 
-    b = Array(Float64, numRows)
+    b = Array{Float64}(numRows)
 
     I_m = Int[]
     J_m = Int[]

--- a/src/StructJuMP.jl
+++ b/src/StructJuMP.jl
@@ -1,4 +1,4 @@
-#__precompile__()
+__precompile__()   # need to be commented for examples/PowerGrid to be run properly
 
 module StructJuMP
 
@@ -7,8 +7,8 @@ import MathProgBase
 import ReverseDiffSparse
 
 # These modules could be optional.
-import StructJuMPSolverInterface
-import MPI
+# import StructJuMPSolverInterface ## need to be uncommented for exmples/PowerGrid to be run properly
+# import MPI                       ## need to be uncommented for examples/PowerGrid to be run properly
 
 export StructuredModel, getStructure, getparent, getchildren, getProcIdxSet,
        num_scenarios, @second_stage, getprobability, getMyRank,

--- a/src/StructJuMP.jl
+++ b/src/StructJuMP.jl
@@ -1,4 +1,4 @@
-__precompile__()
+#__precompile__()
 
 module StructJuMP
 
@@ -7,8 +7,8 @@ import MathProgBase
 import ReverseDiffSparse
 
 # These modules could be optional.
-# import StructJuMPSolverInterface
-# import MPI
+import StructJuMPSolverInterface
+import MPI
 
 export StructuredModel, getStructure, getparent, getchildren, getProcIdxSet,
        num_scenarios, @second_stage, getprobability, getMyRank,


### PR DESCRIPTION
PowerGrid examples are now compatible with Julia 0.6.1. 

One thing to keep in mind to run power grid examples is that some lines in src/StructJuMP.jl have to be either commented or uncommented. It is documented in src/StructJuMP.jl file. 